### PR TITLE
fix: added a docker:dev and docker:prod file, and makefile to build them

### DIFF
--- a/Dockerfile-dmriprep
+++ b/Dockerfile-dmriprep
@@ -1,0 +1,5 @@
+FROM dmriprep:dev
+
+ADD . /dmriprep
+WORKDIR /dmriprep
+RUN python /dmriprep/setup.py install

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,9 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+docker-dev: ## build the development environment
+	docker build -t dmriprep:dev -f docker/Dockerfile docker/.
+
+docker: docker-dev
+	docker build -t dmriprep:prod -f Dockerfile-dmriprep .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,15 +97,6 @@ RUN export PATH="/opt/miniconda-latest/bin:$PATH" \
 #            boto3 \
 #     && sync && conda clean -tipsy && sync
 
-ADD environment.yml environment.yml
-RUN apt-get update && apt-get install -y git gcc
-RUN conda env create -f environment.yml
-
-#&& sync && conda clean -tipsy && sync
-
-
-RUN sed -i '$isource activate dmriprep' $ND_ENTRYPOINT
-
 
 ENV FREESURFER_HOME="/opt/freesurfer-6.0.0" \
     PATH="/opt/freesurfer-6.0.0/bin:$PATH"
@@ -140,6 +131,16 @@ RUN apt-get update -qq \
     && sed -i '$isource "/opt/freesurfer-6.0.0/SetUpFreeSurfer.sh"' "$ND_ENTRYPOINT"
 
 COPY ./license.txt /opt/freesurfer-6.0.0/license.txt
+
+ADD environment.yml environment.yml
+RUN apt-get update && apt-get install -y git gcc
+RUN conda env create -f environment.yml
+
+#&& sync && conda clean -tipsy && sync
+
+
+RUN sed -i '$isource activate dmriprep' $ND_ENTRYPOINT
+
 
 RUN echo '{ \
     \n  "pkg_manager": "apt", \

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -6,6 +6,7 @@ dependencies:
    - dipy
    - boto3
    - graphviz
+   - ipython
    - pip:
      - "--editable=git+https://github.com/nipy/nipype@fa0a101fec2d010dcb68910000f66d7c64e5d03e#egg=nipype"
      - bids


### PR DESCRIPTION
now you can run `make docker` to build a development dmriprep (without the repo installed) and a production dmriprep (with the repo installed)