### PR TITLE
Preserve dim info and use `get_n_slices` to resolve orientation uncertainty

### DIFF
--- a/dmriprep/run.py
+++ b/dmriprep/run.py
@@ -489,7 +489,16 @@ def get_dmriprep_pe_workflow():
         img = nib.load(op.abspath(in_file))
         img_data = img.get_fdata()
         img_data_thinned = np.delete(img_data, drop_scans, axis=3)
-        img_thinned = nib.Nifti1Image(img_data_thinned.astype(np.float64), img.affine, header=img.header)
+        if isinstance(img, nib.nifti1.Nifti1Image):
+            img_thinned = nib.Nifti1Image(img_data_thinned.astype(np.float64),
+                                          img.affine,
+                                          header=img.header)
+        elif isinstance(img, nib.nifti2.Nifti2Image):
+            img_thinned = nib.Nifti2Image(img_data_thinned.astype(np.float64),
+                                          img.affine,
+                                          header=img.header)
+        else:
+            raise TypeError("in_file does not contain Nifti image datatype.")
 
         out_file = fname_presuffix(in_file, suffix="_thinned", newpath=op.abspath('.'))
         nib.save(img_thinned, op.abspath(out_file))

--- a/dmriprep/run.py
+++ b/dmriprep/run.py
@@ -407,7 +407,8 @@ def get_dmriprep_pe_workflow():
             return len([d for d in outliers if d['scan'] == scan])
 
         if 0 < threshold < 1:
-            threshold *= nib.load(dwi_file).shape[2]
+            img = nib.load(dwi_file)
+            threshold *= img.shape[img.header.get_n_slices()]
 
         drop_scans = np.array([
             s for s in scans
@@ -488,7 +489,9 @@ def get_dmriprep_pe_workflow():
 
         img = nib.load(op.abspath(in_file))
         img_data = img.get_fdata()
-        img_data_thinned = np.delete(img_data, drop_scans, axis=3)
+        img_data_thinned = np.delete(img_data,
+                                     drop_scans,
+                                     axis=3)
         if isinstance(img, nib.nifti1.Nifti1Image):
             img_thinned = nib.Nifti1Image(img_data_thinned.astype(np.float64),
                                           img.affine,


### PR DESCRIPTION
Resolves #35 
Resolves #32 

This PR preserves the header information after dropping the volumes with too many outliers.
It also uses the `get_n_slices()` method to determine the number of slices instead of assuming that the 2nd axis (0-based) is the slice dimension.

When dropping volumes, we still hard code `axis=3` to drop from the volume (i.e. scan) dimension. Looking over the Nifti format, I think that this assumption is safe.