### PR TITLE
Fix nslices error in id_outliers_fn

### DIFF
--- a/dmriprep/run.py
+++ b/dmriprep/run.py
@@ -402,7 +402,7 @@ def get_dmriprep_pe_workflow():
 
         if 0 < threshold < 1:
             img = nib.load(dwi_file)
-            threshold *= img.shape[img.header.get_n_slices()]
+            threshold *= img.header.get_n_slices()
 
         drop_scans = np.array([
             s for s in scans


### PR DESCRIPTION
Fixes error with use of `get_n_slices()` method in `id_outliers_fn`.