### PR TITLE
Add utils with is_hemispherical function and a unit test

### DIFF
--- a/dmriprep/utils.py
+++ b/dmriprep/utils.py
@@ -1,0 +1,66 @@
+"""
+Utility functions for other submodules
+
+"""
+import itertools
+
+import numpy as np
+
+
+mod_logger = logging.getLogger(__name__)
+
+
+def is_hemispherical(vecs):
+    """Test whether all points on a unit sphere lie in the same hemisphere.
+
+    Parameters
+    ----------
+    vecs : numpy.ndarray
+        2D numpy array with shape (N, 3) where N is the number of points.
+        All points must lie on the unit sphere.
+
+    Returns
+    -------
+    is_hemi : bool
+        If True, one can find a hemisphere that contains all the points.
+        If False, then the points do not lie in any hemisphere
+
+    pole : numpy.ndarray
+        If `is_hemi == True`, then pole is the "central" pole of the
+        input vectors. Otherwise, pole is the zero vector.
+
+    References
+    ----------
+    https://rstudio-pubs-static.s3.amazonaws.com/27121_a22e51b47c544980bad594d5e0bb2d04.html
+    """
+    if vecs.shape[1] != 3:
+        raise ValueError("Input vectors must be 3D vectors")
+    if not np.allclose(1, np.linalg.norm(vecs, axis=1)):
+        raise ValueError("Input vectors must be unit vectors")
+
+    # Generate all pairwise cross products
+    v0, v1 = zip(*[p for p in itertools.permutations(vecs, 2)])
+    cross_prods = np.cross(v0, v1)
+
+    # Normalize them
+    cross_prods /= np.linalg.norm(cross_prods, axis=1)[:, np.newaxis]
+
+    # `cross_prods` now contains all candidate vertex points for "the polygon"
+    # in the reference. "The polygon" is a subset. Find which points belong to
+    # the polygon using a dot product test with each of the original vectors
+    angles = np.arccos(np.dot(cross_prods, vecs.transpose()))
+
+    # And test whether it is orthogonal or less
+    dot_prod_test = angles <= np.pi / 2.0
+
+    # If there is at least one point that is orthogonal or less to each
+    # input vector, then the points lie on some hemisphere
+    is_hemi = len(vecs) in np.sum(dot_prod_test.astype(int), axis=1)
+
+    if is_hemi:
+        vertices = cross_prods[np.sum(dot_prod_test.astype(int), axis=1) == len(vecs)]
+        pole = np.mean(vertices, axis=0)
+        pole /= np.linalg.norm(pole)
+    else:
+        pole = np.array([0.0, 0.0, 0.0])
+    return is_hemi, pole

--- a/dmriprep/utils.py
+++ b/dmriprep/utils.py
@@ -31,7 +31,7 @@ def is_hemispherical(vecs):
 
     References
     ----------
-    https://rstudio-pubs-static.s3.amazonaws.com/27121_a22e51b47c544980bad594d5e0bb2d04.html
+    https://rstudio-pubs-static.s3.amazonaws.com/27121_a22e51b47c544980bad594d5e0bb2d04.html  # noqa
     """
     if vecs.shape[1] != 3:
         raise ValueError("Input vectors must be 3D vectors")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `dmriprep` package."""
+
+import numpy as np
+
+from dmriprep.utils import is_hemispherical
+
+
+def uniform_points_on_sphere(npoints=1, hemisphere=True, rotate=(0, 0, 0)):
+    """Generate random uniform points on a unit (hemi)sphere."""
+    r = 1.0
+    if hemisphere:
+        theta = np.random.uniform(0, np.pi / 2, npoints)
+    else:
+        theta = np.random.uniform(0, np.pi, npoints)
+    phi = np.random.uniform(0, 2 * np.pi, npoints)
+
+    x = r * np.sin(theta) * np.cos(phi)
+    y = r * np.sin(theta) * np.sin(phi)
+    z = r * np.cos(theta)
+
+    vecs = np.stack([x, y, z])
+
+    rot_x = np.array([
+        [1.0, 0.0, 0.0],
+        [0.0, np.cos(rotate[0]), -np.sin(rotate[0])],
+        [0.0, np.sin(rotate[0]), np.cos(rotate[0])]
+    ])
+
+    rot_y = np.array([
+        [np.cos(rotate[1]), 0.0, np.sin(rotate[1])],
+        [0.0, 1.0, 0.0],
+        [-np.sin(rotate[1]), 0.0, np.cos(rotate[1])]
+    ])
+
+    rot_z = np.array([
+        [np.cos(rotate[2]), -np.sin(rotate[2]), 0.0],
+        [np.sin(rotate[2]), np.cos(rotate[2]), 0.0],
+        [0.0, 0.0, 1.0]
+    ])
+
+    vecs = np.dot(rot_z, np.dot(rot_y, np.dot(rot_x, vecs)))
+
+    return vecs.transpose()
+
+
+def test_is_hemispherical():
+    vecs = uniform_points_on_sphere(
+        npoints=100,
+        hemisphere=True,
+        rotate=(np.random.uniform(0, np.pi),
+                np.random.uniform(0, np.pi),
+                np.random.uniform(0, np.pi))
+    )
+
+    assert is_hemispherical(vecs)[0]
+    vecs = uniform_points_on_sphere(npoints=100, hemisphere=False)
+    assert not is_hemispherical(vecs)[0]


### PR DESCRIPTION
This PR adds a function to test if vectors all lie within a hemisphere (any hemisphere).
This should be used in the solutions to #58 with something like

```
from dipy.io import read_bvals_bvecs
bvals, bvecs = read_bvals_bvecs(fbval, fbvec)

from .utils import is_hemispherical
if is_hemispherical(bvecs)[0]:
    # Do not have spherical acquisition, use FLIRT
else:
    # We have a spherical acquisition, use eddy
```

The `is_hemispherical` function also returns the central pole of the input points just in case we need that at some point.